### PR TITLE
Bunch of convoluted  old vs new GOST text.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.refcache/**

--- a/draft-hardaker-dnsop-must-not-ecc-gost.md
+++ b/draft-hardaker-dnsop-must-not-ecc-gost.md
@@ -29,6 +29,8 @@ normative:
   RFC4035:
   RFC5933:
   RFC8080:
+  RFC9364:
+
   DNSKEY-IANA:
     author:
       name: IANA
@@ -42,6 +44,7 @@ normative:
 
 informative:
   RFC8499:
+  RFC9558:
 
 
 --- abstract
@@ -61,7 +64,7 @@ in DNSSEC is documented in {{RFC9558}}, and so {{RFC5933}} has been made
 Historic.
 
 Thus, the use of GOST R 34.10-2001 (mnemonic GOST-ECC) and and GOST R 34.11-94
-is no not recommend for use in DNSSEC {{RFC4033}} {{RFC4034}} {{RFC4035}}.
+is no not recommend for use in DNSSEC {{RFC9364}}.
 
 Note that this document does not change or discuss the use of GOST 34.10-2012
 and GOST 34.11-2012.

--- a/draft-hardaker-dnsop-must-not-ecc-gost.md
+++ b/draft-hardaker-dnsop-must-not-ecc-gost.md
@@ -1,5 +1,5 @@
 ---
-title: "Remove ECC-GOST from active use within DNSSEC"
+title: "Remove GOST 94 from active use within DNSSEC"
 abbrev: MUST NOT DNSSEC with ECC-GOST
 docname: draft-hardaker-dnsop-must-not-ecc-gost-00
 category: std
@@ -52,13 +52,19 @@ This document retires the use of ECC-GOST within DNSSEC.
 
 # Introduction
 
-The security of the ECC-GOST algorithm {{RFC5933}} has been slowly
-diminishing over time as various forms of attacks have weakened its
-cryptographic underpinning.  Thus, the use of ECC-GOST is no longer
-needed and is not recommend for use in DNSSEC {{RFC4033}} {{RFC4034}}
-{{RFC4035}}.
+The use of the GOST R 34.10-2001 and GOST R 34.11-94 algorithms with DNSSEC was
+documented in {{RFC5933}}. These two algorithms were deprecated by the Orders
+of the Federal Agency for Technical Regulation and Metrology of Russia
+(Rosstandart) in August 2012, and were superseded by GOST 34.10-2012 and
+GOST 34.11-2012 respectively. The use of GOST 34.10-2012 and GOST 34.11-2012
+in DNSSEC is documented in {{RFC9558}}, and so {{RFC5933}} has been made
+Historic.
 
-This document retires the use of ECC-GOST within DNSSEC.
+Thus, the use of GOST R 34.10-2001 (mnemonic GOST-ECC) and and GOST R 34.11-94
+is no not recommend for use in DNSSEC {{RFC4033}} {{RFC4034}} {{RFC4035}}.
+
+Note that this document does not change or discuss the use of GOST 34.10-2012
+and GOST 34.11-2012.
 
 ## Requirements notation
 


### PR DESCRIPTION
This is an attempt to clarify that GOST-ECC means "GOST with the code 12" and not "GOST-12" :-P 

"there is GOST and GOST, and this deprecates GOST but not GOST, got it? Good..."

